### PR TITLE
Code coverage integration with codecov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -292,3 +292,6 @@ tools/
 
 # vs code config file
 .vscode/
+
+# coverage reports
+coverage.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ mono: latest
 dotnet: 2.1.4
 os:
   - linux
-  - osx
-osx_image: xcode8.2
 
 script:
-  - ./build.sh
+  - ./build.sh -t UploadCoverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,4 @@ os:
 
 script:
   - ./build.sh
+  - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ os:
   - linux
 
 script:
-  - ./build.sh -t UploadCoverage
+  - ./build.sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Academia
 
 [![Build Status](https://travis-ci.org/techcombd/academia.svg?branch=master)](https://travis-ci.org/techcombd/academia)
+[![codecov](https://codecov.io/gh/techcombd/academia/branch/master/graph/badge.svg)](https://codecov.io/gh/techcombd/academia)
 [![GitHub license](https://img.shields.io/github/license/techcombd/academia.svg)](https://github.com/techcombd/academia/blob/master/LICENSE)
 [![GitHub issues](https://img.shields.io/github/issues/techcombd/academia.svg)](https://github.com/techcombd/academia/issues)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Academia
 
 [![Build Status](https://travis-ci.org/techcombd/academia.svg?branch=master)](https://travis-ci.org/techcombd/academia)
+[![Build status](https://ci.appveyor.com/api/projects/status/rq56t7j772m25m1t/branch/master?svg=true)](https://ci.appveyor.com/project/ratanparai/academia/branch/master)
 [![codecov](https://codecov.io/gh/techcombd/academia/branch/master/graph/badge.svg)](https://codecov.io/gh/techcombd/academia)
 [![GitHub license](https://img.shields.io/github/license/techcombd/academia.svg)](https://github.com/techcombd/academia/blob/master/LICENSE)
 [![GitHub issues](https://img.shields.io/github/issues/techcombd/academia.svg)](https://github.com/techcombd/academia/issues)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
 image: Visual Studio 2015
 
 build_script:
-  -ps: .\build.ps1 -Target UploadCoverage
+  - ps: .\build.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 image: Visual Studio 2015
 
 environment:
-  nodejs_version: "8.11.1"
+  nodejs_version: "8"
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,4 @@
+image: Visual Studio 2015
+
+build_script:
+  -ps: .\build.ps1 -Target UploadCoverage

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,10 @@
 image: Visual Studio 2015
 
+environment:
+  nodejs_version: "8.11.1"
+
+install:
+  - ps: Install-Product node $env:nodejs_version
+
 build_script:
   - ps: .\build.ps1

--- a/build.cake
+++ b/build.cake
@@ -1,6 +1,4 @@
 #addin "Cake.Npm"
-#tool nuget:?package=Codecov
-#addin nuget:?package=Cake.Codecov
 
 ///////////////////////////////////////////////////////////////////////////////
 // ARGUMENTS
@@ -9,7 +7,6 @@
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Release");
 var solution = File("./Academia.sln");
-var coverageDir = MakeAbsolute(Directory("./coverage"));
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -81,18 +78,10 @@ Task("Test")
             new DotNetCoreTestSettings
             {
                 NoBuild = true,
-                ArgumentCustomization = args=>args.Append("/p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutputDirectory=" + coverageDir)
+                ArgumentCustomization = args=>args.Append("/p:CollectCoverage=true /p:CoverletOutputFormat=opencover")
             }
         );
     }
-});
-
-Task("UploadCoverage")
-.IsDependentOn("Test")
-.Does(() =>
-{
-    // Upload a coverage report.
-    Codecov("coverage/coverage.xml");
 });
 
 Task("Default")

--- a/tests/UnitTests/UnitTests.csproj
+++ b/tests/UnitTests/UnitTests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="coverlet.msbuild" Version="1.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />


### PR DESCRIPTION
At first I tried to use [OpenCover](https://github.com/OpenCover/opencover) to calculate code coverage. But it doesn't run on `Linux` and faced some trouble running the script on `Windows` machine too. So now using [coverlet](https://github.com/tonerdo/coverlet) for code coverage. So far working good. 

Although  `Web` project's coverage is not calculated. May be because it is not `referenced` by the `UnitTests` test project. 