### PR TITLE
generate code coverage using OpenCover

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,3 @@ os:
 
 script:
   - ./build.sh
-  - bash <(curl -s https://codecov.io/bash)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,10 @@
-image: Visual Studio 2015
+image: Visual Studio 2017
 
 environment:
   nodejs_version: "8"
+
+init:
+  - choco install opencover.portable
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,4 +7,10 @@ install:
   - ps: Install-Product node $env:nodejs_version
 
 build_script:
-  - ps: .\build.ps1
+  - ps: .\build.ps1 -Target OpenCover
+
+after_build:
+  - ps: |
+      $env:PATH = 'C:\msys64\usr\bin;' + $env:PATH
+      Invoke-WebRequest -Uri 'https://codecov.io/bash' -OutFile codecov.sh
+      bash codecov.sh

--- a/build.cake
+++ b/build.cake
@@ -84,6 +84,32 @@ Task("Test")
     }
 });
 
+#tool "nuget:?package=OpenCover"
+Task("OpenCover")
+.IsDependentOn("Build")
+.Does(() => {
+    var projectFiles = GetFiles("./tests/**/*.csproj");
+    var coverageNumber = 1;
+    foreach(var file in projectFiles)
+    {
+        OpenCover(tool => {
+            tool.DotNetCoreTest(file.FullPath,
+                new DotNetCoreTestSettings
+                {
+                    NoBuild = true}
+            );
+        },
+        new FilePath("result"+ coverageNumber +".xml"),
+        new OpenCoverSettings{
+            OldStyle = true,
+            Register = "user"
+        });
+
+        coverageNumber++;
+
+    }
+});
+
 Task("Default")
 .IsDependentOn("Test");
 

--- a/build.cake
+++ b/build.cake
@@ -89,7 +89,6 @@ Task("OpenCover")
 .IsDependentOn("Build")
 .Does(() => {
     var projectFiles = GetFiles("./tests/**/*.csproj");
-    var coverageNumber = 1;
     foreach(var file in projectFiles)
     {
         OpenCover(tool => {
@@ -99,13 +98,11 @@ Task("OpenCover")
                     NoBuild = true}
             );
         },
-        new FilePath("result"+ coverageNumber +".xml"),
+        new FilePath("./" + file.GetDirectory() + "/coverage.xml"),
         new OpenCoverSettings{
             OldStyle = true,
             Register = "user"
         });
-
-        coverageNumber++;
 
     }
 });

--- a/build.cake
+++ b/build.cake
@@ -102,7 +102,8 @@ Task("OpenCover")
         new OpenCoverSettings{
             OldStyle = true,
             Register = "user"
-        });
+        }
+        .WithFilter("+[Academia*]*"));
 
     }
 });


### PR DESCRIPTION
Currently we are using `Coverlet` but it doesn't support brunch coverage. So moved code coverage generation to `AppVeyor` CI using `OpenCover`