### PR TITLE
add initial integration test

### DIFF
--- a/tests/IntegrationTests/IntegrationTests.csproj
+++ b/tests/IntegrationTests/IntegrationTests.csproj
@@ -6,11 +6,27 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <!-- https://github.com/NuGet/Home/issues/4412. -->
+  <Target Name="CopyDepsFiles" AfterTargets="Build" Condition="'$(TargetFramework)'!=''">
+    <ItemGroup>
+      <DepsFilePaths Include="$([System.IO.Path]::ChangeExtension('%(_ResolvedProjectReferencePaths.FullPath)', '.deps.json'))" />
+    </ItemGroup>
+
+    <Copy SourceFiles="%(DepsFilePaths.FullPath)" DestinationFolder="$(OutputPath)" Condition="Exists('%(DepsFilePaths.FullPath)')" />
+  </Target>
+
   <ItemGroup>
+    <PackageReference Include="coverlet.msbuild" Version="1.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Academia.Core\Academia.Core.csproj" />
+    <ProjectReference Include="..\..\src\Academia.Web\Academia.Web.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/IntegrationTests/Web/ApiInstituteControllerShould.cs
+++ b/tests/IntegrationTests/Web/ApiInstituteControllerShould.cs
@@ -1,0 +1,64 @@
+﻿using Academia.Core.Entities;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace IntegrationTests.Web
+{
+    public class ApiInstituteControllerShould : BaseWebTest
+    {
+
+        [Fact]
+        public async Task ReturnWithCurrectMessage()
+        {
+            var response = await _client.GetAsync("/api/Institute");
+            response.EnsureSuccessStatusCode();
+            var stringResponse = await response.Content.ReadAsStringAsync();
+
+            // We do not seed any institutes so the default list should be empty
+            Assert.Equal("[]", stringResponse);
+        }
+
+        [Fact]
+        public async Task AddInstitute()
+        {
+
+            var institute = new Institute
+            {
+                Name = "The Best Institute",
+                Address = "Dhaka"
+            };
+
+            var serializedInstitute = JsonConvert.SerializeObject(institute);
+
+            var content = new StringContent(serializedInstitute, Encoding.UTF8, "application/json");
+            var response = await _client.PostAsync("/api/Institute", content);
+            response.EnsureSuccessStatusCode();
+
+            var responseString = await response.Content.ReadAsStringAsync();
+            var responseInstitute = JsonConvert.DeserializeObject<Institute>(responseString);
+
+            Assert.Equal(institute.Name, responseInstitute.Name);
+
+            var getResponse = await _client.GetAsync("/api/Institute");
+            getResponse.EnsureSuccessStatusCode();
+            var responseAllInstitute = await getResponse.Content.ReadAsStringAsync();
+            var responseFromGetInstitute = JsonConvert.DeserializeObject<Institute[]>(responseAllInstitute);
+
+            var length = responseFromGetInstitute.Length;
+            Assert.Equal(1, length);
+
+            var singleResponse = await _client.GetAsync("/api/Institute/" + responseInstitute.Id);
+            singleResponse.EnsureSuccessStatusCode();
+            var responseSingleInstituteString = await singleResponse.Content.ReadAsStringAsync();
+
+            var instituteSingleGet = JsonConvert.DeserializeObject<Institute>(responseSingleInstituteString);
+            Assert.Equal(institute.Name, instituteSingleGet.Name);
+            
+        }
+
+    }
+}

--- a/tests/IntegrationTests/Web/BaseWebTest.cs
+++ b/tests/IntegrationTests/Web/BaseWebTest.cs
@@ -1,0 +1,71 @@
+﻿using Academia.Web;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.PlatformAbstractions;
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Reflection;
+
+namespace IntegrationTests.Web
+{
+    public abstract class BaseWebTest
+    {
+
+        protected readonly HttpClient _client;
+        protected string _contentRoot;
+
+        public BaseWebTest()
+        {
+            _client = GetClient();
+        }
+
+        private HttpClient GetClient()
+        {
+            var startUpAssembly = typeof(Startup).GetTypeInfo().Assembly;
+            _contentRoot = GetProjectPath("src", startUpAssembly);
+            var builder = new WebHostBuilder()
+                .UseContentRoot(_contentRoot)
+                .UseStartup<Startup>()
+                .UseEnvironment("Testing");
+
+            var server = new TestServer(builder);
+            return server.CreateClient();
+        }
+
+        /// <summary>
+        /// Gets the full path to the target project path that we wish to test
+        /// </summary>
+        /// <param name="solutionRelativePath">
+        /// The parent directory of the target project.
+        /// e.g. src, samples, test, or test/Websites
+        /// </param>
+        /// <param name="startupAssembly">The target project's assembly.</param>
+        /// <returns>The full path to the target project.</returns>
+        private static string GetProjectPath(string solutionRelativePath, Assembly startupAssembly)
+        {
+            // Get name of the target project which we want to test
+            var projectName = startupAssembly.GetName().Name;
+
+            // Get currently executing test project path
+            var applicationBasePath = PlatformServices.Default.Application.ApplicationBasePath;
+
+            // Find the folder which contains the solution file. We then use this information to find the target
+            // project which we want to test.
+            var directoryInfo = new DirectoryInfo(applicationBasePath);
+            do
+            {
+                var solutionFileInfo = new FileInfo(Path.Combine(directoryInfo.FullName, "Academia.sln"));
+                if (solutionFileInfo.Exists)
+                {
+                    return Path.GetFullPath(Path.Combine(directoryInfo.FullName, solutionRelativePath, projectName));
+                }
+
+                directoryInfo = directoryInfo.Parent;
+            }
+            while (directoryInfo.Parent != null);
+
+            throw new Exception($"Solution root could not be located using application root {applicationBasePath}.");
+        }
+    }
+}


### PR DESCRIPTION
Configure integration test project. Every integration test should extend `BaseWebTest` class and use `_client` abstract object to send request to `URL`

closes #2 