### PR TITLE
Offline code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -295,3 +295,4 @@ tools/
 
 # coverage reports
 coverage.xml
+reports/

--- a/README.md
+++ b/README.md
@@ -14,3 +14,25 @@ School Management System
 Before building from source make sure you have [NET Core SDK](https://www.microsoft.com/net/download) and [Node.js](https://nodejs.org/) installed on your system.
 
 To run a complete build on command line only, install [Node.js](https://nodejs.org/) and execute `build.cmd` or `build.sh` without arguments.
+
+## Code Coverage Report
+
+You can generate `Code Coverage Report` in `HTML` format by running from `Windows Powershell`-
+
+```
+.\build.ps1 -Target CodeCoverage
+```
+
+or from `Windows` `cmd` -
+
+```
+build.cmd -Target CodeCoverage
+```
+
+and from `Linux` or `MacOSX` -
+
+```
+./build.sh -Target CodeCoverage
+```
+
+The `Coverage` report will be generated inside `reports` directory of your project `root`

--- a/build.bat
+++ b/build.bat
@@ -1,3 +1,3 @@
 @ECHO OFF
-PowerShell -NoProfile -NoLogo -ExecutionPolicy unrestricted -Command "[System.Threading.Thread]::CurrentThread.CurrentCulture = ''; [System.Threading.Thread]::CurrentThread.CurrentUICulture = '';& '%~dp0build.ps1'; exit $LASTEXITCODE"
+PowerShell -NoProfile -NoLogo -ExecutionPolicy unrestricted -Command "[System.Threading.Thread]::CurrentThread.CurrentCulture = ''; [System.Threading.Thread]::CurrentThread.CurrentUICulture = '';& '%~dp0build.ps1'%*; exit $LASTEXITCODE"
 PAUSE

--- a/build.cake
+++ b/build.cake
@@ -113,6 +113,7 @@ Task("CodeCoverage")
 .Does(() => {
     if (IsRunningOnUnix())
     {
+        Information("Linux! Running Coverlet for code coverage");
         RunTarget("Test");
     } else {
         Information("Windows! Running OpenCover");

--- a/build.cake
+++ b/build.cake
@@ -108,6 +108,22 @@ Task("OpenCover")
     }
 });
 
+#tool "nuget:?package=ReportGenerator"
+Task("CodeCoverage")
+.Does(() => {
+    if (IsRunningOnUnix())
+    {
+        RunTarget("Test");
+    } else {
+        Information("Windows! Running OpenCover");
+        RunTarget("OpenCover");
+    }
+
+    ReportGenerator("./tests/*/coverage.xml", "reports", new ReportGeneratorSettings(){
+        HistoryDirectory = "reports/history"
+    });
+});
+
 Task("Default")
 .IsDependentOn("Test");
 

--- a/build.ps1
+++ b/build.ps1
@@ -85,7 +85,7 @@ function GetProxyEnabledWebClient
 {
     $wc = New-Object System.Net.WebClient
     $proxy = [System.Net.WebRequest]::GetSystemWebProxy()
-    $proxy.Credentials = [System.Net.CredentialCache]::DefaultCredentials        
+    $proxy.Credentials = [System.Net.CredentialCache]::DefaultCredentials
     $wc.Proxy = $proxy
     return $wc
 }
@@ -115,8 +115,8 @@ if ((Test-Path $PSScriptRoot) -and !(Test-Path $TOOLS_DIR)) {
 
 # Make sure that packages.config exist.
 if (!(Test-Path $PACKAGES_CONFIG)) {
-    Write-Verbose -Message "Downloading packages.config..."    
-    try {        
+    Write-Verbose -Message "Downloading packages.config..."
+    try {
         $wc = GetProxyEnabledWebClient
         $wc.DownloadFile("https://cakebuild.net/download/bootstrapper/packages", $PACKAGES_CONFIG) } catch {
         Throw "Could not download packages.config."

--- a/build.sh
+++ b/build.sh
@@ -9,14 +9,10 @@
 # Define directories.
 SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 TOOLS_DIR=$SCRIPT_DIR/tools
-ADDINS_DIR=$TOOLS_DIR/Addins
-MODULES_DIR=$TOOLS_DIR/Modules
 NUGET_EXE=$TOOLS_DIR/nuget.exe
 CAKE_EXE=$TOOLS_DIR/Cake/Cake.exe
 PACKAGES_CONFIG=$TOOLS_DIR/packages.config
 PACKAGES_CONFIG_MD5=$TOOLS_DIR/packages.config.md5sum
-ADDINS_PACKAGES_CONFIG=$ADDINS_DIR/packages.config
-MODULES_PACKAGES_CONFIG=$MODULES_DIR/packages.config
 
 # Define md5sum or md5 depending on Linux/OSX
 MD5_EXE=
@@ -28,14 +24,24 @@ fi
 
 # Define default arguments.
 SCRIPT="build.cake"
-CAKE_ARGUMENTS=()
+TARGET="Default"
+CONFIGURATION="Release"
+VERBOSITY="verbose"
+DRYRUN=
+SHOW_VERSION=false
+SCRIPT_ARGUMENTS=()
 
 # Parse arguments.
 for i in "$@"; do
     case $1 in
         -s|--script) SCRIPT="$2"; shift ;;
-        --) shift; CAKE_ARGUMENTS+=("$@"); break ;;
-        *) CAKE_ARGUMENTS+=("$1") ;;
+        -t|--target) TARGET="$2"; shift ;;
+        -c|--configuration) CONFIGURATION="$2"; shift ;;
+        -v|--verbosity) VERBOSITY="$2"; shift ;;
+        -d|--dryrun) DRYRUN="-dryrun" ;;
+        --version) SHOW_VERSION=true ;;
+        --) shift; SCRIPT_ARGUMENTS+=("$@"); break ;;
+        *) SCRIPT_ARGUMENTS+=("$1") ;;
     esac
     shift
 done
@@ -67,45 +73,19 @@ fi
 
 # Restore tools from NuGet.
 pushd "$TOOLS_DIR" >/dev/null
-if [ ! -f "$PACKAGES_CONFIG_MD5" ] || [ "$( cat "$PACKAGES_CONFIG_MD5" | sed 's/\r$//' )" != "$( $MD5_EXE "$PACKAGES_CONFIG" | awk '{ print $1 }' )" ]; then
-    find . -type d ! -name . ! -name 'Cake.Bakery' | xargs rm -rf
+if [ ! -f $PACKAGES_CONFIG_MD5 ] || [ "$( cat $PACKAGES_CONFIG_MD5 | sed 's/\r$//' )" != "$( $MD5_EXE $PACKAGES_CONFIG | awk '{ print $1 }' )" ]; then
+    find . -type d ! -name . | xargs rm -rf
 fi
 
 mono "$NUGET_EXE" install -ExcludeVersion
 if [ $? -ne 0 ]; then
-    echo "Could not restore NuGet tools."
+    echo "Could not restore NuGet packages."
     exit 1
 fi
 
-$MD5_EXE "$PACKAGES_CONFIG" | awk '{ print $1 }' >| "$PACKAGES_CONFIG_MD5"
+$MD5_EXE $PACKAGES_CONFIG | awk '{ print $1 }' >| $PACKAGES_CONFIG_MD5
 
 popd >/dev/null
-
-# Restore addins from NuGet.
-if [ -f "$ADDINS_PACKAGES_CONFIG" ]; then
-    pushd "$ADDINS_DIR" >/dev/null
-
-    mono "$NUGET_EXE" install -ExcludeVersion
-    if [ $? -ne 0 ]; then
-        echo "Could not restore NuGet addins."
-        exit 1
-    fi
-
-    popd >/dev/null
-fi
-
-# Restore modules from NuGet.
-if [ -f "$MODULES_PACKAGES_CONFIG" ]; then
-    pushd "$MODULES_DIR" >/dev/null
-
-    mono "$NUGET_EXE" install -ExcludeVersion
-    if [ $? -ne 0 ]; then
-        echo "Could not restore NuGet modules."
-        exit 1
-    fi
-
-    popd >/dev/null
-fi
 
 # Make sure that Cake has been installed.
 if [ ! -f "$CAKE_EXE" ]; then
@@ -114,4 +94,8 @@ if [ ! -f "$CAKE_EXE" ]; then
 fi
 
 # Start Cake
-exec mono "$CAKE_EXE" $SCRIPT "${CAKE_ARGUMENTS[@]}"
+if $SHOW_VERSION; then
+    exec mono "$CAKE_EXE" -version
+else
+    exec mono "$CAKE_EXE" $SCRIPT -verbosity=$VERBOSITY -configuration=$CONFIGURATION -target=$TARGET $DRYRUN "${SCRIPT_ARGUMENTS[@]}"
+fi


### PR DESCRIPTION
Generate code coverage depending on `OS` by running the build script using arguments -

```
-Target CodeCoverage
```

with details instruction in `README.md` file.

closes #27 