### PR TITLE
update bugfix

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -44,16 +44,6 @@ Task("Restore")
     DotNetCoreRestore();
 });
 
-Task("NpmRestore")
-.Does(() => {
-    var settings = new NpmInstallSettings();
-
-    settings.LogLevel = NpmLogLevel.Info;
-    settings.WorkingDirectory = "src/Academia.Web/ClientApp";
-
-    NpmInstall(settings);
-});
-
 Task("NgTestCoverage")
 .Does(() => {
     //Build Angular frontend project using Angular cli
@@ -75,7 +65,6 @@ Task("NgTestCoverage")
 Task("Build")
 .IsDependentOn("Clean")
 .IsDependentOn("Restore")
-.IsDependentOn("NpmRestore")
 .Does(() => {
     DotNetCoreBuild(solution,
         new DotNetCoreBuildSettings

--- a/src/Academia.Web/Controllers/InstituteController.cs
+++ b/src/Academia.Web/Controllers/InstituteController.cs
@@ -86,13 +86,17 @@ namespace Academia.Web.Controllers
                 return BadRequest();
             }
 
-            //var ins = await _instituteRepository.GetByIdAsync(id);
-            //if(ins == null)
-            //{
-            //    return NotFound();
-            //}
+            var efInstitute = await _instituteRepository.GetByIdAsync(id);
+            if (efInstitute == null)
+            {
+                return NotFound();
+            }
 
-            await _instituteRepository.UpdateAsync(institute);
+            efInstitute.Name = institute.Name;
+            efInstitute.Address = institute.Address;
+            efInstitute.Email = institute.Email;
+
+            await _instituteRepository.UpdateAsync(efInstitute);
 
             return new NoContentResult();
         }

--- a/tests/IntegrationTests/Web/ApiInstituteControllerShould.cs
+++ b/tests/IntegrationTests/Web/ApiInstituteControllerShould.cs
@@ -85,7 +85,7 @@ namespace IntegrationTests.Web
 
             var createInstitute = await ShouldCreateNewInstitute(institute);
 
-            institute.Name = "New Name";
+            createInstitute.Name = "New Name";
             var instituteJsonSerialized = JsonConvert.SerializeObject(createInstitute);
             var content = new StringContent(instituteJsonSerialized, Encoding.UTF8, "application/json");
 
@@ -93,6 +93,14 @@ namespace IntegrationTests.Web
             response.EnsureSuccessStatusCode();
 
             Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+
+            // now check if the institute is updated
+            var getResponse = await _client.GetAsync("/api/institute/" + createInstitute.Id);
+            getResponse.EnsureSuccessStatusCode();
+            var responseString = await getResponse.Content.ReadAsStringAsync();
+            var instituteGetById = JsonConvert.DeserializeObject<Institute>(responseString);
+
+            Assert.Equal(createInstitute.Name, instituteGetById.Name);
                         
         }
 
@@ -116,7 +124,7 @@ namespace IntegrationTests.Web
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         }
 
-        // TODO: make this test pass
+        [Fact]
         public async Task ShouldNotUpdateInstituteIdNotFound()
         {
             var institute = new Institute
@@ -135,7 +143,7 @@ namespace IntegrationTests.Web
 
             var response = await _client.PutAsync("/api/institute/"+ notInDatabaseId, content);
 
-            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         }
     }
 }


### PR DESCRIPTION
Solve institute update api would throw exception if we provide `Id` that is not in the database. 

also remove manual `npm install` command to clean up `CI` console output. 
closes 

close #33 